### PR TITLE
Remove a validation rule

### DIFF
--- a/Suduko/Models/PuzzleModel.cs
+++ b/Suduko/Models/PuzzleModel.cs
@@ -115,12 +115,6 @@ namespace Sudoku.Models
         {
             Cell cell = Cells[index];
 
-            if (!cell.HasValue && (cell.Possibles.Count == 1))
-            {
-                Debug.Fail("cells with calculated values should be disabled");
-                return false;
-            }
-
             if (cell.HasValue && (newValue > 0))
             {
                 Debug.Fail("replacing a cell value directly isn't supported");
@@ -156,12 +150,17 @@ namespace Sudoku.Models
 
             foreach (Cell cell in Cells.CubeRowColumnMinus(updatedCell.Index))
             {
-                if (!cell.HasValue && cell.Possibles[newValue] && (cell.Possibles.Count > 1))
+                if (!cell.HasValue && cell.Possibles[newValue])
                 {
-                    cell.Possibles[newValue] = false;
+                    int count = cell.Possibles.Count;
 
-                    if (cell.Possibles.Count == 1)
-                        cellsToUpdate.Push(cell);
+                    if (count != 1)
+                    {
+                        cell.Possibles[newValue] = false;
+
+                        if (count == 2)
+                            cellsToUpdate.Push(cell);  // only one possible left
+                    }
                 }
             }
         }


### PR DESCRIPTION
A validation rule was checking the UI state which shouldn't be done in the model (the UI worked anyway). It also gave a false negative when opening really simple saved puzzles where the value of a cell was able to be calculated before it was later set by the files contents.