### PR TITLE
Set cell's value origin on delete

### DIFF
--- a/SudokuSolver/ViewModels/PuzzleViewModel.cs
+++ b/SudokuSolver/ViewModels/PuzzleViewModel.cs
@@ -60,7 +60,7 @@ namespace Sudoku.ViewModels
 
             if (Model.ValidateCellValue(changedCell.Index, changedCell.Value))
             {
-                Model.SetCellValue(changedCell.Index, changedCell.Value, Origins.User);
+                Model.SetCellValue(changedCell.Index, changedCell.Value, changedCell.HasValue ? Origins.User : Origins.NotDefined);
 
                 Model.AttemptSimpleTrialAndError();
 


### PR DESCRIPTION
Set the cell's value origin property correctly when the user deletes an existing cell value. This bug had no effect on the programs operation but the property should always reflect the correct state regardless.