### PR TITLE
Add an Enum mapper generic class

### DIFF
--- a/SudokuSolver/Common/EnumMapper.cs
+++ b/SudokuSolver/Common/EnumMapper.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+
+namespace Sudoku.Common
+{
+      /// <summary>
+      /// A mapper for converting between enum field names and their associated values
+      /// and visa versa. This could be useful if your enum type contains a small number
+      /// of values and you need to convert formats regularly. 
+      /// </summary>
+      /// <typeparam name="T"></typeparam>
+    internal class EnumMapper<T> where T : struct, Enum
+    {
+        private readonly Dictionary<string, T> valueLookUp = new Dictionary<string, T>();
+        private readonly Dictionary<T, string> nameLookUp = new Dictionary<T, string>();
+
+        private int initialised = 0;
+
+        public string ToName(T src)
+        {
+            if (initialised == 0)
+                Init();
+
+            return nameLookUp[src];
+        }
+
+
+        public bool TryGetName(T src, [NotNullWhen(returnValue: true)] out string? name)
+        {
+            if (initialised == 0)
+                Init();
+
+            return nameLookUp.TryGetValue(src, out name);
+        }
+
+
+        public T ToValue(string src)
+        {
+            if (initialised == 0)
+                Init();
+
+            return valueLookUp[src];
+        }
+
+        public bool TryGetValue(string src, out T value)
+        {
+            if (initialised == 0)
+                Init();
+                                                    
+            return valueLookUp.TryGetValue(src, out value);
+        }
+
+
+        private void Init()
+        {
+            if (Interlocked.Exchange(ref initialised, 1) == 0)
+            {
+                foreach (string name in Enum.GetNames(typeof(T)))
+                {
+                    T value = (T)Enum.Parse<T>(name);
+
+                    valueLookUp.Add(name, value);
+                    nameLookUp.Add(value, name);
+                }
+            }
+        }
+    }
+}

--- a/SudokuSolver/Common/Origins.cs
+++ b/SudokuSolver/Common/Origins.cs
@@ -4,4 +4,15 @@ namespace Sudoku.Common
 {
     public enum Origins { NotDefined, User, Calculated, Trial }
 
+
+    internal static class OriginsMapper
+    {
+        private static readonly EnumMapper<Origins> mapper = new EnumMapper<Origins>();
+
+        public static string ToName(Origins src) => mapper.ToName(src);
+
+        public static bool TryGetValue(string src, out Origins origin) => mapper.TryGetValue(src, out origin);
+    }
+
 }
+

--- a/SudokuSolver/Models/Cell.cs
+++ b/SudokuSolver/Models/Cell.cs
@@ -5,7 +5,7 @@ using Sudoku.Common;
 
 namespace Sudoku.Models
 {
-    [DebuggerDisplay("value = {Value}, index = {Index}")]
+    [DebuggerDisplay("[{Index}] value = {Value}, origin = {Sudoku.Common.OriginsMapper.ToName(Origin)}")]
     internal sealed class Cell : CellBase
     {
         public Cell(int index) : base(index)


### PR DESCRIPTION
Add a mapper class that is used to display debug info but is also intended to be used when saving puzzles where the origins property will added as a cell attribute.