### PR TITLE
Update EnumMapper and callers

### DIFF
--- a/SudokuSolver/Common/EnumMapper.cs
+++ b/SudokuSolver/Common/EnumMapper.cs
@@ -6,12 +6,16 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Sudoku.Common
 {
-      /// <summary>
-      /// A mapper for converting between enum field names and their associated values
-      /// and vice versa. This could be useful if your enum type contains a small number
-      /// of values and you need to convert formats regularly. 
-      /// </summary>
-      /// <typeparam name="T"></typeparam>
+    /// <summary>
+    /// A mapper for converting between enum member names and their associated values
+    /// and vice versa. This could be useful if your enum type contains a small number
+    /// of values and you need to convert formats regularly.
+    ///     
+    /// If the enum type has two or more members with the same value (violating design
+    /// rule CA1069) the name returned for that value will be one of the possible names 
+    /// but which name actually returned will be indeterminate.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
     internal sealed class EnumMapper<T> where T : struct, Enum
     {
         private sealed class Mapper
@@ -21,12 +25,18 @@ namespace Sudoku.Common
 
             public Mapper()
             {
-                foreach (string name in Enum.GetNames(typeof(T)))
+                string[] names = Enum.GetNames<T>();
+                T[] values = Enum.GetValues<T>();
+
+                for (int index = 0; index < names.Length; index++)
                 {
-                    T value = Enum.Parse<T>(name);
+                    string name = names[index] ;
+                    T value = values[index];
 
                     valueLookUp.Add(name, value);
-                    nameLookUp.Add(value, name);
+
+                    if ((index == 0) || (!value.Equals(values[index - 1])))
+                        nameLookUp.Add(value, name);
                 }
             }
         }
@@ -47,13 +57,22 @@ namespace Sudoku.Common
             return data.Value.nameLookUp.TryGetValue(src, out name);
         }
 
-        public T ToValue(string src)
+        public T Parse(string? src)
         {
+            if (src == null)
+                throw new ArgumentNullException(nameof(src));
+
             return data.Value.valueLookUp[src];
         }
 
-        public bool TryGetValue(string src, out T value)
-        {                        
+        public bool TryParse(string? src, out T value)
+        {
+            if (src == null)
+            {
+                value = default;
+                return false;
+            }
+
             return data.Value.valueLookUp.TryGetValue(src, out value);
         }
     }

--- a/SudokuSolver/Common/Origins.cs
+++ b/SudokuSolver/Common/Origins.cs
@@ -11,6 +11,6 @@ namespace Sudoku.Common
 
         public static string ToName(Origins src) => mapper.ToName(src);
 
-        public static bool TryGetValue(string src, out Origins origin) => mapper.TryGetValue(src, out origin);
+        public static bool TryParse(string? src, out Origins origin) => mapper.TryParse(src, out origin);
     }
 }

--- a/SudokuSolver/Models/PuzzleModel.cs
+++ b/SudokuSolver/Models/PuzzleModel.cs
@@ -115,7 +115,7 @@ namespace Sudoku.Models
         {
             foreach (XElement cell in document.Descendants(Cx.Cell))
             {
-                if (cell.Element(Cx.origin)?.Value == OriginsMapper.ToName(Origins.User) 
+                if (OriginsMapper.TryParse(cell.Element(Cx.origin)?.Value, out Origins o) && (o == Origins.User)
                     && int.TryParse(cell.Element(Cx.x)?.Value, out int x) && (x >= 0) && (x < 9)
                     && int.TryParse(cell.Element(Cx.y)?.Value, out int y) && (y >= 0) && (y < 9)
                     && int.TryParse(cell.Element(Cx.value)?.Value, out int value) && (value > 0) && (value < 10))


### PR DESCRIPTION
1) Allow for enums that have two or more members with the same value. Previously it threw a duplicate key exception.

2) Change the name of the functions that convert from a string to Parse() and TryParse() and making the string parameter a possible null value. This fits the expected convention.

3) Update callers accordingly and now use TryParse() function when reading xml files.