### PR TITLE
Allow calculated cells to be edited

### DIFF
--- a/SudokuSolver/ViewModels/Cell.cs
+++ b/SudokuSolver/ViewModels/Cell.cs
@@ -9,33 +9,24 @@ namespace Sudoku.ViewModels
     {
         public event PropertyChangedEventHandler? PropertyChanged;
 
-
         public Cell(int index, PropertyChangedEventHandler callBack) : base(index)
         {
             PropertyChanged += callBack;
         }
 
-
-
         public override int Value
         {
             set
             {
-                if (base.Value != value)
-                {
-                    base.Value = value;
-                    NotifyPropertyChanged(nameof(Value));
-                }
+                base.Value = value;
+                NotifyPropertyChanged(nameof(Value)); // always notify even if the value hasn't changed
             }
         }
-
 
         private void NotifyPropertyChanged(String propertyName)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
-
-
 
         public void RevertValue(int value)
         {

--- a/SudokuSolver/Views/Cell.xaml
+++ b/SudokuSolver/Views/Cell.xaml
@@ -38,18 +38,6 @@
             </Style.Triggers>
         </Style>
     </UserControl.Resources>
-    <UserControl.Style>
-        <Style TargetType="UserControl">
-            <Style.Triggers>
-                <DataTrigger Binding="{Binding ElementName=SudokuCell, Path=Origin}" Value="Trial">
-                    <Setter Property="IsEnabled" Value="false"/>
-                </DataTrigger>
-                <DataTrigger Binding="{Binding ElementName=SudokuCell, Path=Origin}" Value="Calculated">
-                    <Setter Property="IsEnabled" Value="false"/>
-                </DataTrigger>
-            </Style.Triggers>
-        </Style>
-    </UserControl.Style>
 
     <Canvas Height="50" Width="50">
 


### PR DESCRIPTION
The trouble with solving as you type is that the puzzle can be solved before you've typed in all the numbers. While the solution is valid it isn't the same as puzzle that was intended. This change allows calculated cell values to be edited so the puzzle can be entered correctly.