### PR TITLE
Revert view model cell value

### DIFF
--- a/SudokuSolver/ViewModels/PuzzleViewModel.cs
+++ b/SudokuSolver/ViewModels/PuzzleViewModel.cs
@@ -116,6 +116,8 @@ namespace Sudoku.ViewModels
                     SystemSounds.Beep.Play();
                 }
             }
+            else
+                changedCell.RevertValue(previousValue);
         }
 
 


### PR DESCRIPTION
If the user deletes a calculated cell value the model isn't called because it would just recalculate that value. However the view model cells value still needed to be reverted.  This bug was introduced with PR #49