### PR TITLE
Add a missing NotifyPropertyChanged() call

### DIFF
--- a/SudokuSolver/ViewModels/PuzzleViewModel.cs
+++ b/SudokuSolver/ViewModels/PuzzleViewModel.cs
@@ -249,6 +249,7 @@ namespace Sudoku.ViewModels
                 {
                     darkThemed = value;
                     ThemeManager.Current.ChangeThemeBaseColor(Application.Current, darkThemed ? ThemeManager.BaseColorDark : ThemeManager.BaseColorLight);
+                    NotifyPropertyChanged();
                 }
             }
         }


### PR DESCRIPTION
If the app started with the system in dark mode the corresponding dark theme menu item wasn't checked.