### PR TITLE
Update symbol font family reference

### DIFF
--- a/SudokuSolver/Views/MainWindow.xaml
+++ b/SudokuSolver/Views/MainWindow.xaml
@@ -32,7 +32,7 @@
         <Menu DockPanel.Dock="Top">
             <Menu.Resources>
                 <Style TargetType="TextBlock">
-                    <Setter Property="FontFamily" Value="Segoe MDL2 Assets, /MahApps.Metro;component/Assets/#Segoe MDL2 Assets"/>
+                    <Setter Property="FontFamily" Value="{StaticResource MahApps.Fonts.Family.SymbolTheme}"/>
                     <Setter Property="VerticalAlignment" Value="Center"/>
                     <Setter Property="FontSize" Value="16"/>
                     <Setter Property="Padding" Value="5,0,5,0"/>
@@ -71,7 +71,7 @@
             </MenuItem>
         </Menu>
 
-        <local:PuzzleView VerticalAlignment="Center" HorizontalAlignment="Center" Padding="5,5,5,5"/>
+        <local:PuzzleView VerticalAlignment="Center" HorizontalAlignment="Center" Padding="5"/>
 
     </DockPanel>
 </mah:MetroWindow>


### PR DESCRIPTION
Load the MahApps font family definition rather than explicity fall back to its embeded resource. I tried that before but it didn't work, typo probably...