### PR TITLE
Rewrite the SudokuGrid

### DIFF
--- a/SudokuSolver/Views/PuzzleView.xaml
+++ b/SudokuSolver/Views/PuzzleView.xaml
@@ -7,10 +7,20 @@
     mc:Ignorable="d" 
     d:DesignHeight="480" 
     d:DesignWidth="480">
-    <Viewbox>
-        <local:SudokuGrid CellBorderThickness="1" CubeBorderBrush="{DynamicResource MahApps.Brushes.Text}">
-            <local:Cell Data="{Binding Cells[0]}" />
-            <local:Cell Data="{Binding Cells[1]}" />
+    <Viewbox >
+        <local:SudokuGrid>
+            <local:SudokuGrid.Resources>
+                <Style TargetType="Line" x:Key="MinorGridStyle">
+                    <Setter Property="Stroke" Value="Gray"/>
+                    <Setter Property="StrokeThickness" Value="1"/>
+                </Style>
+                <Style TargetType="Line" x:Key="MajorGridStyle">
+                    <Setter Property="Stroke" Value="{DynamicResource MahApps.Brushes.Text}"/>
+                    <Setter Property="StrokeThickness" Value="2"/>
+                </Style>
+            </local:SudokuGrid.Resources>
+            <local:Cell Data="{Binding Cells[0]}"/>
+            <local:Cell Data="{Binding Cells[1]}"/>
             <local:Cell Data="{Binding Cells[2]}" />
             <local:Cell Data="{Binding Cells[3]}" />
             <local:Cell Data="{Binding Cells[4]}" />
@@ -90,6 +100,29 @@
             <local:Cell Data="{Binding Cells[78]}" />
             <local:Cell Data="{Binding Cells[79]}" />
             <local:Cell Data="{Binding Cells[80]}" />
+            <!-- minor grid lines -->
+            <Line Style="{StaticResource MinorGridStyle}"/>
+            <Line Style="{StaticResource MinorGridStyle}"/>
+            <Line Style="{StaticResource MinorGridStyle}"/>
+            <Line Style="{StaticResource MinorGridStyle}"/>
+            <Line Style="{StaticResource MinorGridStyle}"/>
+            <Line Style="{StaticResource MinorGridStyle}"/>
+            <Line Style="{StaticResource MinorGridStyle}"/>
+            <Line Style="{StaticResource MinorGridStyle}"/>
+            <Line Style="{StaticResource MinorGridStyle}"/>
+            <Line Style="{StaticResource MinorGridStyle}"/>
+            <Line Style="{StaticResource MinorGridStyle}"/>
+            <Line Style="{StaticResource MinorGridStyle}"/>
+            <!-- internal major grid lines -->
+            <Line Style="{StaticResource MajorGridStyle}"/>
+            <Line Style="{StaticResource MajorGridStyle}"/>
+            <Line Style="{StaticResource MajorGridStyle}"/>
+            <Line Style="{StaticResource MajorGridStyle}"/>
+            <!-- major grid lines forming the enclosing rectangle -->
+            <Line Style="{StaticResource MajorGridStyle}"/>
+            <Line Style="{StaticResource MajorGridStyle}"/>
+            <Line Style="{StaticResource MajorGridStyle}"/>
+            <Line Style="{StaticResource MajorGridStyle}"/>
         </local:SudokuGrid>
     </Viewbox>
 </UserControl>

--- a/SudokuSolver/Views/SudokuGrid.cs
+++ b/SudokuSolver/Views/SudokuGrid.cs
@@ -1,119 +1,65 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Media;
+using System.Windows.Shapes;
 
 namespace Sudoku.Views
 {
     internal sealed class SudokuGrid : Panel
     {
+        private double minorGridLineWidth = 0.0;   
+        private double majorGridLineWidth = 0.0;
+        private double cellSize = 0.0;
 
-        public static readonly DependencyProperty CellBorderThicknessProperty =
-            DependencyProperty.Register(nameof(CellBorderThickness),
-                typeof(double),
-                typeof(SudokuGrid),
-                new FrameworkPropertyMetadata(0.5D,
-                    FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender),
-                SudokuGrid.ValidateThickness);
+        private const int cCellCount = 81;
+        private const int cMinorGridLineCount = 12;
+        private const int cMajorGridLineCount = 8;
 
-
-        public static readonly DependencyProperty CellBorderBrushProperty =
-            DependencyProperty.Register(nameof(CellBorderBrush),
-                typeof(Brush),
-                typeof(SudokuGrid),
-                new FrameworkPropertyMetadata(new SolidColorBrush(Color.FromArgb(0xFF, 0x88, 0x88, 0x88)),
-                    FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender));
+        private const int cValidChildrenCount = cCellCount + cMinorGridLineCount + cMajorGridLineCount;
 
 
-
-
-        public static readonly DependencyProperty CubeBorderThicknessProperty =
-            DependencyProperty.Register(nameof(CubeBorderThickness),
-                typeof(double),
-                typeof(SudokuGrid),
-                new FrameworkPropertyMetadata(2.0D,
-                    FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender),
-                new ValidateValueCallback(SudokuGrid.ValidateThickness));
-
-
-        public static readonly DependencyProperty CubeBorderBrushProperty =
-            DependencyProperty.Register(nameof(CubeBorderBrush),
-                typeof(Brush),
-                typeof(SudokuGrid),
-                new FrameworkPropertyMetadata(new SolidColorBrush(Color.FromArgb(0xFF, 0x00, 0x00, 0x00)),
-                    FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender));
-
-
-
-        public double CellBorderThickness
+        private double TotalWidthOfBorders()
         {
-            get { return (double)GetValue(SudokuGrid.CellBorderThicknessProperty); }
-            set { base.SetValue(SudokuGrid.CellBorderThicknessProperty, value); }
+            return (minorGridLineWidth * (cMinorGridLineCount / 2)) + (majorGridLineWidth * (cMajorGridLineCount / 2));
         }
 
 
-        public Brush CellBorderBrush
+        private void InitializeGridLineSizes()
         {
-            get { return (Brush)GetValue(SudokuGrid.CellBorderBrushProperty); }
-            set { base.SetValue(SudokuGrid.CellBorderBrushProperty, value); }
+            if (Children[cCellCount] is Line minorLine)
+                minorGridLineWidth = minorLine.StrokeThickness;
+
+            if (Children[cCellCount + cMinorGridLineCount] is Line majorLine)
+                majorGridLineWidth = majorLine.StrokeThickness;
         }
 
-
-
-        public double CubeBorderThickness
-        {
-            get { return (double)GetValue(SudokuGrid.CubeBorderThicknessProperty); }
-            set { base.SetValue(SudokuGrid.CubeBorderThicknessProperty, value); }
-        }
-
-        public Brush CubeBorderBrush
-        {
-            get { return (Brush)GetValue(SudokuGrid.CubeBorderBrushProperty); }
-            set { base.SetValue(SudokuGrid.CubeBorderBrushProperty, value); }
-        }
-
-
-
-        // pretty arbitrary but seems reasonable limits
-        private static bool ValidateThickness(object o)
-        {
-            double d = (double)o;
-            return !double.IsNaN(d) && (d >= 0.1) && (d <= 5.00);
-        }
-
-
-        private double TotalWidthOfBorders() => (4.0 * CubeBorderThickness) + (6.0 * CellBorderThickness);
 
 
         // Calculates the desired size of the grid
         protected override Size MeasureOverride(Size constraint)
         {
+            // it's in a view box, all constraints will be infinite
+            Debug.Assert(double.IsInfinity(constraint.Height) && double.IsInfinity(constraint.Width));
 
-            double constraintSize = Math.Min(constraint.Width, constraint.Height);
-
-            double borderThickness = TotalWidthOfBorders();
-
-            double childSize = (constraintSize - borderThickness) / 9.0;
-
-            Size availableSize = new Size(childSize, childSize);
-
-
-            foreach (UIElement? child in InternalChildren)
+            if (Children.Count == cValidChildrenCount)
             {
-                child?.Measure(availableSize);   // causes the child to update it's desired size
+                InitializeGridLineSizes();
+
+                foreach (UIElement child in Children)
+                    child?.Measure(constraint);   // the child will update it's desired size
+
+                // copy the new cell desired size for future reference
+                cellSize = Children[0].DesiredSize.Width;
+
+                Size desiredSize = new Size();
+                desiredSize.Width = (cellSize * 9.0) + TotalWidthOfBorders();
+                desiredSize.Height = desiredSize.Width;
+
+                return desiredSize;
             }
 
-            Size desiredSize;
-
-            if (InternalChildren.Count > 0)
-                desiredSize = base.InternalChildren[0].DesiredSize;  // all cells are the same size
-            else
-                desiredSize = Size.Empty;  // for design time only
-
-            desiredSize.Width = (desiredSize.Width * 9.0) + borderThickness;
-            desiredSize.Height = desiredSize.Width;
-
-            return desiredSize;
+            return Size.Empty;  // for design time only
         }
 
 
@@ -123,26 +69,33 @@ namespace Sudoku.Views
         // Define the layout of the child elements within the grid
         protected override Size ArrangeOverride(Size arrangeSize)
         {
-            double borderThickness = TotalWidthOfBorders();
+            if (Children.Count == cValidChildrenCount)
+            {
+                ArrangeCells();
+                ArrangeGridLines(arrangeSize);
+            }
 
-            double cellSize = (DesiredSize.Width - borderThickness) / 9.0;
+            return arrangeSize;
+        }
 
+
+        private void ArrangeCells()
+        {
             double[] offsets = new double[9];
 
-            offsets[0] = CubeBorderThickness;
-            offsets[1] = offsets[0] + CellBorderThickness + cellSize;
-            offsets[2] = offsets[1] + CellBorderThickness + cellSize;
-            offsets[3] = offsets[2] + CubeBorderThickness + cellSize;
-            offsets[4] = offsets[3] + CellBorderThickness + cellSize;
-            offsets[5] = offsets[4] + CellBorderThickness + cellSize;
-            offsets[6] = offsets[5] + CubeBorderThickness + cellSize;
-            offsets[7] = offsets[6] + CellBorderThickness + cellSize;
-            offsets[8] = offsets[7] + CellBorderThickness + cellSize;
+            offsets[0] = majorGridLineWidth;
+            offsets[1] = offsets[0] + minorGridLineWidth + cellSize;
+            offsets[2] = offsets[1] + minorGridLineWidth + cellSize;
+            offsets[3] = offsets[2] + majorGridLineWidth + cellSize;
+            offsets[4] = offsets[3] + minorGridLineWidth + cellSize;
+            offsets[5] = offsets[4] + minorGridLineWidth + cellSize;
+            offsets[6] = offsets[5] + majorGridLineWidth + cellSize;
+            offsets[7] = offsets[6] + minorGridLineWidth + cellSize;
+            offsets[8] = offsets[7] + minorGridLineWidth + cellSize;
 
-            int index = 0;
             Rect finalRect = new Rect(0, 0, cellSize, cellSize);
 
-            foreach (UIElement? uIElement in InternalChildren)
+            for (int index = 0; index < cCellCount; index++) 
             {
                 int x = index % 9;
                 int y = index / 9;
@@ -150,88 +103,70 @@ namespace Sudoku.Views
                 finalRect.X = offsets[x];
                 finalRect.Y = offsets[y];
 
-                uIElement?.Arrange(finalRect);
-                ++index;
+                Children[index].Arrange(finalRect);
             }
-
-            return arrangeSize;
         }
 
 
-        protected override void OnRender(DrawingContext dc)
+        private void ArrangeGridLines(Size arrangeSize)
         {
-            // draw children
-            base.OnRender(dc);
-
-            if (InternalChildren.Count == 0) // for design time only 
-                return;
-
-            // draw grids
             // the horizontal grid lines have the same dimensions as the vertical
             // grid lines but rotated by 90 degrees - swap x and y coordinates
+            Rect finalRect = new Rect(0, 0, arrangeSize.Width, arrangeSize.Height);
 
-            if ((CellBorderThickness > 0.0) && (CellBorderBrush != null))
+            for (int index = 0; index < 20; index += 2)
             {
-                Pen pen = new Pen(CellBorderBrush, CellBorderThickness);
+                Line horizontalLine = (Line)Children[cCellCount + index];
 
-                double n = pen.Thickness * 0.5;
-                double cellWidth = InternalChildren[0].RenderSize.Width;
+                horizontalLine.Y1 = horizontalLine.Y2 = CalculateOffset(index);
 
-                Point verticalA = new Point(0.0, CubeBorderThickness);  // left vertical top 
-                Point verticalB = new Point(0.0, (CubeBorderThickness * 3.0) + (cellWidth * 9.0) + (CellBorderThickness * 6.0));  // left vertical bottom
+                // the last four major grid lines have different start  
+                // and end points because they form the enclosing rectangle
+                horizontalLine.X1 = (index < 16) ? majorGridLineWidth : 0.0 ;
+                horizontalLine.X2 = arrangeSize.Width - horizontalLine.X1;
+                                                                                                     
+                horizontalLine.Arrange(finalRect);
 
-                Point horizontalA = new Point(verticalA.Y, verticalA.X); // top horizontal left
-                Point horizontalB = new Point(verticalB.Y, verticalB.X); // top horizontal right
+                Line verticalLine = (Line)Children[cCellCount + index + 1];
 
-                double[] offsets = new double[6];
+                verticalLine.X1 = horizontalLine.Y1;
+                verticalLine.Y1 = horizontalLine.X1;
 
-                offsets[0] = CubeBorderThickness + cellWidth + n;
-                offsets[1] = offsets[0] + cellWidth + CellBorderThickness;
-                offsets[2] = offsets[1] + (cellWidth * 2) + CubeBorderThickness + CellBorderThickness;
-                offsets[3] = offsets[2] + cellWidth + CellBorderThickness;
-                offsets[4] = offsets[3] + (cellWidth * 2) + CubeBorderThickness + CellBorderThickness;
-                offsets[5] = offsets[4] + cellWidth + CellBorderThickness;
+                verticalLine.X2 = horizontalLine.Y2;
+                verticalLine.Y2 = horizontalLine.X2;
 
-                for (int index = 0; index < 6; ++index)
-                {
-                    Vector xOffset = new Vector(offsets[index], 0.0);
-                    Vector yOffset = new Vector(0.0, offsets[index]);
+                verticalLine.Arrange(finalRect);
+            }
+        }
 
-                    dc.DrawLine(pen, Point.Add(verticalA, xOffset), Point.Add(verticalB, xOffset));
-                    dc.DrawLine(pen, Point.Add(horizontalA, yOffset), Point.Add(horizontalB, yOffset));
-                }
+
+        private double CalculateOffset(int index)
+        {
+            double CalculateOffset(int majorGridLines, int cells, int minorGridLines, double lineWidth)
+            {
+                return (majorGridLineWidth * majorGridLines) + (cellSize * cells) +
+                        (minorGridLineWidth * minorGridLines) + (lineWidth * 0.5);
             }
 
-
-            if ((CubeBorderThickness > 0.0) && (CubeBorderBrush != null))
+            switch (index)
             {
-                Pen pen = new Pen(CubeBorderBrush, CubeBorderThickness);
+                case 0: return CalculateOffset(1, 1, 0, minorGridLineWidth);
+                case 2: return CalculateOffset(1, 2, 1, minorGridLineWidth);
+                case 4: return CalculateOffset(2, 4, 2, minorGridLineWidth);
+                case 6: return CalculateOffset(2, 5, 3, minorGridLineWidth);
+                case 8: return CalculateOffset(3, 7, 4, minorGridLineWidth);
+                case 10: return CalculateOffset(3, 8, 5, minorGridLineWidth);
 
-                double n = pen.Thickness * 0.5;
-                double cellWidth = InternalChildren[0].RenderSize.Width;
+                // internal major grid lines
+                case 12: return CalculateOffset(1, 3, 2, majorGridLineWidth);
+                case 14: return CalculateOffset(2, 6, 4, majorGridLineWidth);
 
-                Point verticalA = new Point(n, 0.0);  // left vertical top
-                Point verticalB = new Point(n, DesiredSize.Height);  // left vertical bottom
-
-                Point horizontalA = new Point(verticalA.Y, verticalA.X); // top horizontal left
-                Point horizontalB = new Point(verticalB.Y, verticalB.X); // top horizontal right
-
-                double[] offsets = new double[4];
-
-                offsets[0] = 0.0;
-                offsets[1] = pen.Thickness + (CellBorderThickness * 2.0) + (cellWidth * 3.0);
-                offsets[2] = offsets[1] * 2.0;
-                offsets[3] = offsets[1] * 3.0;
-
-                for (int index = 0; index < 4; ++index)
-                {
-                    Vector xOffset = new Vector(offsets[index], 0.0);
-                    Vector yOffset = new Vector(0.0, offsets[index]);
-
-                    dc.DrawLine(pen, Point.Add(verticalA, xOffset), Point.Add(verticalB, xOffset));
-                    dc.DrawLine(pen, Point.Add(horizontalA, yOffset), Point.Add(horizontalB, yOffset));
-                }
+                // major grid lines forming the enclosing rectangle 
+                case 16: return CalculateOffset(0, 0, 0, majorGridLineWidth);
+                case 18: return CalculateOffset(3, 9, 6, majorGridLineWidth);
             }
+
+            throw new ArgumentOutOfRangeException(nameof(index));
         }
     }
 }


### PR DESCRIPTION
The old code overrode the OnRender() method and drew the grid lines on top of the panel. This wouldn't work on UWP because drawing is further abstracted and there is no OnRender() method to override. The code now specifies the grid lines in xaml and uses the Measure/Arrange layout passes to set the line dimensions.