### PR TITLE
Stop using style triggers to set theme text colours

### DIFF
--- a/SudokuSolver/App.xaml
+++ b/SudokuSolver/App.xaml
@@ -10,7 +10,7 @@
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
                 <!-- the following theme is the application's default theme -->
-                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Themes/Light.Steel.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/SudokuSolver;component/themes/lighttheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
             <Style x:Key="MainWindowStyle" TargetType="{x:Type mah:MetroWindow}">

--- a/SudokuSolver/Themes/DarkTheme.xaml
+++ b/SudokuSolver/Themes/DarkTheme.xaml
@@ -1,0 +1,17 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:System="clr-namespace:System;assembly=mscorlib"
+                    xmlns:local="clr-namespace:Sudoku.Themes">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Themes/Dark.Steel.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
+    <!-- the theme controller uses the Key to identify this dictionary and its theme -->
+    <System:String x:Key="842B87BE-910E-467F-9C29-3647D0A16453">dark</System:String>
+
+    <!-- these are the cell text foreground brushes -->
+    <SolidColorBrush x:Key="CalculatedCellBrush" Color="#FF0000B4"/>
+    <SolidColorBrush x:Key="TrialCellBrush" Color="DarkGreen"/>
+
+</ResourceDictionary>

--- a/SudokuSolver/Themes/LightTheme.xaml
+++ b/SudokuSolver/Themes/LightTheme.xaml
@@ -1,0 +1,17 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:System="clr-namespace:System;assembly=mscorlib"
+                    xmlns:local="clr-namespace:Sudoku.Themes">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Themes/Light.Steel.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
+    <!-- the theme controller uses the Key to identify this dictionary and its theme -->
+    <System:String x:Key="842B87BE-910E-467F-9C29-3647D0A16453">light</System:String>
+
+    <!-- these are the cell text foreground brushes -->
+    <SolidColorBrush x:Key="CalculatedCellBrush" Color="LightBlue"/>
+    <SolidColorBrush x:Key="TrialCellBrush" Color="LightGreen"/>
+
+</ResourceDictionary>

--- a/SudokuSolver/Themes/ThemeController.cs
+++ b/SudokuSolver/Themes/ThemeController.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Windows;
+
+namespace Sudoku.Themes
+{
+                    
+    internal static class ThemeController
+    {
+        private sealed class Implementation
+        {
+            private enum ThemeType { none, light, dark };
+
+            private const string cUID_Key = "842B87BE-910E-467F-9C29-3647D0A16453";
+            private const string cLightThemeKeyValue = "light";
+            private const string cDarkThemeKeyValue = "dark";
+            private const string cLightThemeLocation = "pack://application:,,,/SudokuSolver;component/themes/lighttheme.xaml";
+            private const string cDarkThemeLocation = "pack://application:,,,/SudokuSolver;component/themes/darktheme.xaml";
+
+            private readonly ResourceDictionary lightTheme;
+            private readonly ResourceDictionary darkTheme;
+
+            public Implementation()
+            {
+                lightTheme = new ResourceDictionary { Source = new Uri(cLightThemeLocation) };
+                darkTheme = new ResourceDictionary { Source = new Uri(cDarkThemeLocation) };
+            }
+
+            private static ThemeType IdentifyTheme(string? themeType)
+            {
+                if (themeType == cLightThemeKeyValue)
+                    return ThemeType.light;
+
+                if (themeType == cDarkThemeKeyValue)
+                    return ThemeType.dark;
+
+                return ThemeType.none;
+            }
+
+            private static ThemeType FindCurrentTheme(FrameworkElement frameworkElement)
+            {
+                return IdentifyTheme(frameworkElement.TryFindResource(cUID_Key) as string);
+            }
+
+            private static ThemeType FindCurrentTheme(Application app)
+            {
+                return IdentifyTheme(app.TryFindResource(cUID_Key) as string);
+            }
+
+            private static void DeleteExistingTheme(ResourceDictionary resources)
+            {
+                ResourceDictionary? existingTheme = null;
+
+                // this will only delete at the current level of the tree
+                // because this is where the themed resource will be added
+                foreach (ResourceDictionary rd in resources.MergedDictionaries)
+                {
+                    if (rd.Contains(cUID_Key))
+                    {
+                        existingTheme = rd;
+                        break;
+                    }
+                }
+
+                if (existingTheme is not null)
+                    resources.MergedDictionaries.Remove(existingTheme);
+            }
+
+            private void SetTheme(ResourceDictionary resources, ThemeType newTheme, ThemeType currentTheme)
+            {
+                if (currentTheme != newTheme)
+                {
+                    resources.BeginInit();
+
+                    if (currentTheme != ThemeType.none)
+                        DeleteExistingTheme(resources);
+
+                    if (newTheme != ThemeType.none)
+                        resources.MergedDictionaries.Add(newTheme == ThemeType.light ? lightTheme : darkTheme);
+
+                    resources.EndInit();
+                }
+            }
+
+            public void SetLightTheme(Application app)
+            {
+                SetTheme(app.Resources, ThemeType.light, FindCurrentTheme(app));
+            }
+
+            public void SetDarkTheme(Application app)
+            {
+                SetTheme(app.Resources, ThemeType.dark, FindCurrentTheme(app));
+            }
+
+            public void SetLightTheme(FrameworkElement element)
+            {
+                SetTheme(element.Resources, ThemeType.light, FindCurrentTheme(element));
+            }
+
+            public void SetDarkTheme(FrameworkElement element)
+            {
+                SetTheme(element.Resources, ThemeType.dark, FindCurrentTheme(element));
+            }
+        }
+        
+        private static Lazy<Implementation> imp = new Lazy<Implementation>(() => { return new Implementation(); });
+
+        public static void SetLightTheme(Application app) => imp.Value.SetLightTheme(app);
+        public static void SetDarkTheme(Application app) => imp.Value.SetDarkTheme(app);
+        public static void SetLightTheme(FrameworkElement element) => imp.Value.SetLightTheme(element);
+        public static void SetDarkTheme(FrameworkElement element) => imp.Value.SetDarkTheme(element);
+    }
+}

--- a/SudokuSolver/ViewModels/PuzzleViewModel.cs
+++ b/SudokuSolver/ViewModels/PuzzleViewModel.cs
@@ -30,21 +30,6 @@ namespace Sudoku.ViewModels
         }
 
 
-        public PuzzleViewModel(PuzzleViewModel source)
-        {
-            Model = new PuzzleModel(source.Model);
-            Cells = new CellList(CellChanged_EventHandler);
-            ClearCommand = new RelayCommand(ClearCommandHandler, o => Cells.NotEmpty);
-
-            foreach (Models.Cell cell in Model.Cells)
-                Cells.UpdateCell(cell);
-
-            DarkThemed = source.DarkThemed;
-            ShowPossibles = source.ShowPossibles;
-            AccentTitleBar = source.AccentTitleBar;
-        }
-
-
         // an empty implementation used to indicate no action is required
         // when the user changes a cell. As the code supports nullable using
         // this avoids the need to return a null function delegate.

--- a/SudokuSolver/Views/Cell.xaml
+++ b/SudokuSolver/Views/Cell.xaml
@@ -13,7 +13,7 @@
 
     <UserControl.Resources>
         <System:Double x:Key="cell_size">50</System:Double>
-        <SolidColorBrush x:Key="DarkishBlue" Color="#FF0000B4"/>
+        
 
         <Style TargetType="TextBlock">
             <Setter Property="Foreground" Value="LightGray"/>
@@ -29,34 +29,12 @@
                 <DataTrigger Binding="{Binding ElementName=SudokuCell, Path=IsFocused}" Value="true">
                     <Setter Property="Background" Value="{x:Static SystemParameters.WindowGlassBrush}"/>
                 </DataTrigger>
-                <MultiDataTrigger>
-                    <MultiDataTrigger.Conditions>
-                        <Condition Binding="{Binding ElementName=SudokuCell, Path=Origin}" Value="Calculated" />
-                        <Condition Binding="{Binding DarkThemed}" Value="False" />
-                    </MultiDataTrigger.Conditions>
-                    <Setter Property="Foreground" Value="LightBlue" />
-                </MultiDataTrigger>
-                <MultiDataTrigger>
-                    <MultiDataTrigger.Conditions>
-                        <Condition Binding="{Binding ElementName=SudokuCell, Path=Origin}" Value="Calculated" />
-                        <Condition Binding="{Binding DarkThemed}" Value="True" />
-                    </MultiDataTrigger.Conditions>
-                    <Setter Property="Foreground" Value="{StaticResource DarkishBlue}" />
-                </MultiDataTrigger>
-                <MultiDataTrigger>
-                    <MultiDataTrigger.Conditions>
-                        <Condition Binding="{Binding ElementName=SudokuCell, Path=Origin}" Value="Trial" />
-                        <Condition Binding="{Binding DarkThemed}" Value="False" />
-                    </MultiDataTrigger.Conditions>
-                    <Setter Property="Foreground" Value="LightGreen" />
-                </MultiDataTrigger>
-                <MultiDataTrigger>
-                    <MultiDataTrigger.Conditions>
-                        <Condition Binding="{Binding ElementName=SudokuCell, Path=Origin}" Value="Trial" />
-                        <Condition Binding="{Binding DarkThemed}" Value="True" />
-                    </MultiDataTrigger.Conditions>
-                    <Setter Property="Foreground" Value="DarkGreen" />
-                </MultiDataTrigger>
+                <DataTrigger Binding="{Binding ElementName=SudokuCell, Path=Origin}" Value="Calculated">
+                    <Setter Property="Foreground" Value="{DynamicResource CalculatedCellBrush}"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding ElementName=SudokuCell, Path=Origin}" Value="Trial">
+                    <Setter Property="Foreground" Value="{DynamicResource TrialCellBrush}"/>
+                </DataTrigger>
             </Style.Triggers>
         </Style>
     </UserControl.Resources>

--- a/SudokuSolver/Views/MainWindow.xaml.cs
+++ b/SudokuSolver/Views/MainWindow.xaml.cs
@@ -8,6 +8,7 @@ using Microsoft.Win32;
 using ControlzEx.Theming;
 
 using Sudoku.ViewModels;
+using Sudoku.Themes;
 
 namespace Sudoku.Views
 {
@@ -75,18 +76,12 @@ namespace Sudoku.Views
                 PuzzleView puzzleView = new PuzzleView
                 {
                     Padding = new Thickness(Math.Min(printDialog.PrintableAreaHeight, printDialog.PrintableAreaWidth) * (cMarginsPercentage / 100D)),
+                    DataContext = this.DataContext
                 };
 
-                if (((PuzzleViewModel)DataContext).DarkThemed)
-                {
-                    PuzzleViewModel clone = new PuzzleViewModel((PuzzleViewModel)DataContext);
-                    clone.DarkThemed = false;
-                    puzzleView.DataContext = clone;
-                    ThemeManager.Current.ChangeThemeBaseColor(puzzleView, ThemeManager.BaseColorLight);
-                }
-                else
-                    puzzleView.DataContext = DataContext; 
- 
+                // always print using the light theme
+                ThemeController.SetLightTheme(puzzleView);
+
                 printDialog.PrintVisual(puzzleView, "Sudoku puzzle");
             }
         }
@@ -137,7 +132,11 @@ namespace Sudoku.Views
         private void SetTheme(bool dark)
         {
             ((PuzzleViewModel)DataContext).DarkThemed = dark;
-            ThemeManager.Current.ChangeThemeBaseColor(Application.Current, dark ? ThemeManager.BaseColorDark : ThemeManager.BaseColorLight);
+
+            if (dark)
+                ThemeController.SetDarkTheme(Application.Current);
+            else
+                ThemeController.SetLightTheme(Application.Current);
         }
 
         private void DarkThemeCheckedHandler(object sender, RoutedEventArgs e) => SetTheme(dark: true);


### PR DESCRIPTION
Set them in the themes instead. This removes the need to clone the view model when printing.