### PR TITLE
Change major grid line colour in dark theme

### DIFF
--- a/SudokuSolver/Themes/DarkTheme.xaml
+++ b/SudokuSolver/Themes/DarkTheme.xaml
@@ -16,5 +16,6 @@
 
     <!-- make menu check marks higher contrast -->
     <SolidColorBrush x:Key="MahApps.Brushes.CheckmarkFill" Color="White"/>
-
+    <!-- the puzzle grid line -->
+    <SolidColorBrush x:Key="MajorGridLineBrush" Color="LightGray"/>
 </ResourceDictionary>

--- a/SudokuSolver/Themes/LightTheme.xaml
+++ b/SudokuSolver/Themes/LightTheme.xaml
@@ -16,5 +16,6 @@
 
     <!-- make menu check marks higher contrast -->
     <SolidColorBrush x:Key="MahApps.Brushes.CheckmarkFill" Color="Black"/>
-
+    <!-- the puzzle grid line -->
+    <SolidColorBrush x:Key="MajorGridLineBrush" Color="Black"/>
 </ResourceDictionary>

--- a/SudokuSolver/Views/PuzzleView.xaml
+++ b/SudokuSolver/Views/PuzzleView.xaml
@@ -15,7 +15,7 @@
                     <Setter Property="StrokeThickness" Value="1"/>
                 </Style>
                 <Style TargetType="Line" x:Key="MajorGridStyle">
-                    <Setter Property="Stroke" Value="{DynamicResource MahApps.Brushes.Text}"/>
+                    <Setter Property="Stroke" Value="{DynamicResource MajorGridLineBrush}"/>
                     <Setter Property="StrokeThickness" Value="2"/>
                 </Style>
             </local:SudokuGrid.Resources>


### PR DESCRIPTION
Reduce the contrast of the major grid lines. Use light grey instead of white for the dark theme.