### PR TITLE
Use a wpf message box to show errors

### DIFF
--- a/SudokuSolver/Views/ErrorDialog.cs
+++ b/SudokuSolver/Views/ErrorDialog.cs
@@ -1,30 +1,37 @@
 ﻿using MahApps.Metro.Controls;
 using MahApps.Metro.Controls.Dialogs;
-using System.Windows.Input;
+
+using System.Windows;
+using System;
+
+#nullable enable
 
 namespace Sudoku.Views
 {
     internal static class ErrorDialog
     {
+#if UseMahAppsDialog
+
+        // The MahApps in window dialog is visually very good but unfortunately it has problems
+        // with modality. Command bindings of the parent window will still be active and focus 
+        // can be changed to the parent window using access keys. See:
+        // https://github.com/MahApps/MahApps.Metro/issues/2400
+
         public static async void Show(MetroWindow parent, string heading, string details)
         {
             MetroDialogSettings dialogSettings = new MetroDialogSettings()
             {
-                // A bug in MahApps stops access keys from working in this dialog. The
-                // Esc and Enter keys both work though so not really too much of a problem...
                 AffirmativeButtonText = "Close",
-                ColorScheme = MetroDialogColorScheme.Accented,
             };
 
-            // Another bug in MahApps is that the dialog isn't as modal as it should be.
-            // The parent window's command bindings will still be active while the dialog
-            // is open i.e. typing Control+P opens the print dialog.  
-            CommandBindingCollection backup = new CommandBindingCollection(parent.CommandBindings);
-            parent.CommandBindings.Clear();
-
             await parent.ShowMessageAsync(heading, details, MessageDialogStyle.Affirmative, dialogSettings);
-
-            parent.CommandBindings.AddRange(backup);
         }
+#else
+        public static void Show(MetroWindow _, string heading, string message)
+        {
+            string text = heading + System.Environment.NewLine + message;
+            MessageBox.Show(messageBoxText: text, caption: "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+#endif
     }
 }


### PR DESCRIPTION
Errors are rare occurrences so it makes little difference but the MahApps in window dialog has a couple of problems which require too much hacking to work around.