### PR TITLE
Add extra validation when adding a new cell value

### DIFF
--- a/SudokuSolver/Models/PuzzleModel.cs
+++ b/SudokuSolver/Models/PuzzleModel.cs
@@ -6,6 +6,7 @@ using System.Xml.Linq;
 
 using Sudoku.Common;
 
+#nullable enable
 
 namespace Sudoku.Models
 {
@@ -137,9 +138,12 @@ namespace Sudoku.Models
             if (ValidateNewCellValue(index, newValue))
             {
                 SetCellValue(index, newValue, Origins.User);
-                AttemptSimpleTrialAndError();
 
-                return true;
+                if (PuzzleIsErrorFree()) // so far, it doesn't mean the puzzle is still solvable
+                {
+                    AttemptSimpleTrialAndError();
+                    return true;
+                }
             }
 
             return false;


### PR DESCRIPTION
Check the puzzle is still valid after adding a new value and revert it if errors are present. It's not a conclusive test, it's only valid for the current state of the puzzle.