### PR TITLE
Simplify getting enum member names

### DIFF
--- a/SudokuSolver/Models/Cell.cs
+++ b/SudokuSolver/Models/Cell.cs
@@ -8,7 +8,7 @@ using Sudoku.Common;
 namespace Sudoku.Models
 {
 
-    [DebuggerDisplay("[{Index  % 9}, {Index / 9}] value = {Value}, origin = {System.Enum.GetName<Sudoku.Common.Origins>(Origin)}")]
+    [DebuggerDisplay("[{Index  % 9}, {Index / 9}] value = {Value}, origin = {Origin}")]
     internal sealed class Cell : CellBase, IEquatable<Cell>
     {
         public Cell(int index) : base(index)

--- a/SudokuSolver/Models/PuzzleModel.cs
+++ b/SudokuSolver/Models/PuzzleModel.cs
@@ -50,7 +50,7 @@ namespace Sudoku.Models
                     xmlTree.Add(new XElement(Cx.Cell, new XElement(Cx.x, cell.Index % 9),
                                                       new XElement(Cx.y, cell.Index / 9),
                                                       new XElement(Cx.value, cell.Value),
-                                                      new XElement(Cx.origin, Enum.GetName(cell.Origin))));
+                                                      new XElement(Cx.origin, cell.Origin.ToString())));
                 }
             }
 


### PR DESCRIPTION
Use ToString() rather than Enum.GetName()