### PR TITLE
Fix a bug in change #99

### DIFF
--- a/SudokuSolver/ViewModels/PuzzleViewModel.cs
+++ b/SudokuSolver/ViewModels/PuzzleViewModel.cs
@@ -87,7 +87,7 @@ namespace Sudoku.ViewModels
             {
                 if (modelFunction(changedCell.Index, changedCell.Value))
                 {
-                    changedCell.Value = -1;   // forces a cell update
+                    Cells.UpdateCell(Model.Cells[changedCell.Index]);  
                     UpdateView();
                 }
                 else


### PR DESCRIPTION
Setting a cells value to -1 caused the cells HasValue property to fail. This broke deleting cell values. Instead of tricking the update code so it always updated that cell just update it in place.