### PR TITLE
Update Mah.Apps package to 2.4.5

### DIFF
--- a/SudokuSolver/SudokuSolver.csproj
+++ b/SudokuSolver/SudokuSolver.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MahApps.Metro" Version="2.4.4" />
+    <PackageReference Include="MahApps.Metro" Version="2.4.5" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The previous version fixed a rare NRE related to saving the windows state. Unfortunately that fix had issues and needed another release. I'd never seen the original problem but it's probably best to update anyway.