### PR TITLE
Change the BitField's First property signature

### DIFF
--- a/SudokuSolver/Common/BitField.cs
+++ b/SudokuSolver/Common/BitField.cs
@@ -53,11 +53,11 @@ namespace Sudoku.Common
         {
             get
             {
-                nuint mask = 2;
-                int index = 1;
-
                 if (data != 0)
                 {
+                    nuint mask = 2;
+                    int index = 1;
+
                     while ((data & mask) == 0)
                     {
                         index++;
@@ -67,8 +67,7 @@ namespace Sudoku.Common
                     return index;
                 }
 
-                // this property isn't FirstOrDefault
-                throw new InvalidOperationException();
+                return -1;
             }
         }
 

--- a/SudokuSolver/Models/PuzzleModel.cs
+++ b/SudokuSolver/Models/PuzzleModel.cs
@@ -763,10 +763,10 @@ namespace Sudoku.Models
                 if (!cell.HasValue && (cell.Possibles.Count == 2))
                 {
                     BitField temp = cell.Possibles;
-        
-                    while (!temp.IsEmpty)
+                    int value;
+
+                    while ((value = temp.First) > 0)
                     {
-                        int value = temp.First;
                         attempts.Add((cell.Index, value));
                         temp[value] = false;
                     }
@@ -830,18 +830,18 @@ namespace Sudoku.Models
                         originalModel = new PuzzleModel(this);
 
                     BitField temp = cell.Possibles;
+                    int value;
 
-                    while (!temp.IsEmpty)
+                    while ((value = temp.First) > 0)
                     {        
-                        int cellValue = temp.First;
-                        SetCellValue(cell.Index, cellValue, Origins.Trial);
+                        SetCellValue(cell.Index, value, Origins.Trial);
 
                         if (PuzzleIsComplete && PuzzleIsErrorFree())
                             return;
 
                         // revert puzzle and clear the possible value
                         CopyFrom(originalModel);
-                        temp[cellValue] = false;
+                        temp[value] = false;
                     }
                 }
             }


### PR DESCRIPTION
Instead of throwing an exception if the bitfield is empty return -1. This removes the need to call  IsEmpty before First (as in reading lines out of a file). I didn't really like throwing exceptions out of lowish level bit twiddling code.