### PR TITLE
Fix opening saved puzzles when hiding the solution

### DIFF
--- a/SudokuSolver/Models/PuzzleModel.cs
+++ b/SudokuSolver/Models/PuzzleModel.cs
@@ -112,14 +112,14 @@ namespace Sudoku.Models
                 {
                     int index = x + (y * 9);
 
-                    if (ValidateNewCellValue(index, value))
-                        SetCellValue(index, value, Origins.User);
+                    Cells[index].Value = value;
+                    Cells[index].Origin = Origins.User;
                 }
             }
 
+            CalculatePossibleValues(Cells[0], forceRecalculation: true);
             AttemptSimpleTrialAndError();
         }
-
 
         private void OpenVersion_1(XDocument document)
         {
@@ -132,14 +132,14 @@ namespace Sudoku.Models
                 {
                     int index = x + (y * 9);
 
-                    if (ValidateNewCellValue(index, value))
-                        SetCellValue(index, value, Origins.User);
+                    Cells[index].Value = value;
+                    Cells[index].Origin = Origins.User;
                 }
             }
 
+            CalculatePossibleValues(Cells[0], forceRecalculation: true);
             AttemptSimpleTrialAndError();
         }
-
 
         public bool Add(int index, int newValue)
         {


### PR DESCRIPTION
When opening a file the code ignored any user entered values if it had already calculated the cells value. This was ok before you could hide the solution, but now user entered cells always have to be identical to the saved puzzle. The code will now only recalculate the puzzle once when its finished reading the file rather than after reading each cell (even if that was useful for probably excessive file validation).