### PR TITLE
Use floating versioning for MahApps.Metro

### DIFF
--- a/SudokuSolver/SudokuSolver.csproj
+++ b/SudokuSolver/SudokuSolver.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MahApps.Metro" Version="2.4.5" />
+    <PackageReference Include="MahApps.Metro" Version="2.4.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Always use the latest bug fix version. They have fixed another problem with saving the window placement (glad I'm not the only one that has that problem).