### PR TITLE
Go back to recursive sub dirs

### DIFF
--- a/SudokuSolver/Installer/inno_worker.iss
+++ b/SudokuSolver/Installer/inno_worker.iss
@@ -48,8 +48,7 @@ AppUpdatesURL=https://github.com/DHancock/SudokuSolver/releases
 #endif
 
 [Files]
-Source: "*"; DestDir: "{app}"; Excludes: "*.png"
-Source: "Resources\*"; DestDir: "{app}\Resources"
+Source: "*"; DestDir: "{app}"; Flags: recursesubdirs
 
 [Icons]
 Name: "{group}\{#appDisplayName}"; Filename: "{app}\{#appExeName}"


### PR DESCRIPTION
If trimmed and ready to run are switched off excluding the extra files stops the installed app running. That makes testing problematic.