### PR TITLE
Fix app launch redirection

### DIFF
--- a/SudokuSolver/Installer/inno_worker.iss
+++ b/SudokuSolver/Installer/inno_worker.iss
@@ -12,7 +12,7 @@
 
 #define appDisplayName "Sudoku Solver"
 #define appVer "1.5.1"
-#define appName "sudokusolver"
+#define appName "SudokuSolver"
 #define appExeName appName + ".exe"
 #define appId "sudukosolver.8628521D92E74106"
 


### PR DESCRIPTION
Seems that the exe file name has to have the same case as the assembly name.