### PR TITLE
Separate selection from keyboard focus

### DIFF
--- a/SudokuSolver/ViewModels/PuzzleViewModel.cs
+++ b/SudokuSolver/ViewModels/PuzzleViewModel.cs
@@ -242,9 +242,13 @@ internal sealed class PuzzleViewModel : INotifyPropertyChanged
         }
     }
 
-    public void Puzzle_SelectedIndexChanged(object sender, int e)
+    public void Puzzle_SelectedIndexChanged(object sender, Views.Cell.SelectionChangedEventArgs e)
     {
-        selectedIndex = e;
+        if (e.IsSelected)
+            selectedIndex = e.Index;
+        else if (selectedIndex == e.Index)
+            selectedIndex = -1;
+
         RaiseCanExecuteChanged();
     }
 

--- a/SudokuSolver/Views/MainWindow.xaml.cs
+++ b/SudokuSolver/Views/MainWindow.xaml.cs
@@ -109,12 +109,6 @@ internal sealed partial class MainWindow : WindowBase
         {
             await Puzzle.ViewModel.ClipboardContentChanged();
         };
-
-        Activated += (s, e) =>
-        {
-            if (e.WindowActivationState != WindowActivationState.Deactivated)
-                Puzzle.FocusLastSelectedCell();
-        };
     }
 
     private void FocusLastSelectedCell()

--- a/SudokuSolver/Views/PuzzleView.xaml.cs
+++ b/SudokuSolver/Views/PuzzleView.xaml.cs
@@ -9,7 +9,7 @@ internal partial class PuzzleView : UserControl
 {
     private PuzzleViewModel? viewModel;
     private Cell? lastSelectedCell;
-    public event EventHandler<int>? SelectedIndexChanged;
+    public event EventHandler<Cell.SelectionChangedEventArgs>? SelectedIndexChanged;
 
     public bool IsPrintView { get; set; } = false;
 
@@ -40,15 +40,19 @@ internal partial class PuzzleView : UserControl
 
     private void Cell_SelectionChanged(object sender, Cell.SelectionChangedEventArgs e)
     {
-        if (e.IsSelected) 
-        {
-            SelectedIndexChanged?.Invoke(this, e.CellIndex);
+        SelectedIndexChanged?.Invoke(this, e);
 
+        if (e.IsSelected)
+        {
             // enforce single selection
             if (lastSelectedCell is not null)
                 lastSelectedCell.IsSelected = false;
 
             lastSelectedCell = (Cell)sender;
+        }
+        else if (ReferenceEquals(lastSelectedCell, sender))
+        {
+            lastSelectedCell = null;
         }
     }
 


### PR DESCRIPTION
You can now click on a selected cell to deselect it. There doesn't always need to have a selected cell now even if there isn't another control on the window that could be focused instead.