### PR TITLE
Update to WinAppSdk 1.4.0

### DIFF
--- a/SudokuSolver/SudokuSolver.csproj
+++ b/SudokuSolver/SudokuSolver.csproj
@@ -20,10 +20,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.2.229-beta">
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.18-beta">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230502000" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.230822000" />
 	<!-- the build tools are only required for packaged builds to run...
 	<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
 	-->


### PR DESCRIPTION
Due to https://github.com/microsoft/WindowsAppSDK/issues/3602

Both my framework dependent unpackaged apps need to use the latest WinAppSdk release otherwise an install of a dependent framework with a lower 1.n version fails to install the ddlm's if a later version is already installed.