### PR TITLE
Close menus on window closing if puzzle is dirty

### DIFF
--- a/SudokuSolver/GlobalUsings.cs
+++ b/SudokuSolver/GlobalUsings.cs
@@ -2,6 +2,7 @@
 global using Microsoft.UI.Windowing;
 global using Microsoft.UI.Xaml;
 global using Microsoft.UI.Xaml.Controls;
+global using Microsoft.UI.Xaml.Controls.Primitives;
 global using Microsoft.UI.Xaml.Input;
 global using Microsoft.UI.Xaml.Media;
 global using Microsoft.UI.Xaml.Media.Imaging;

--- a/SudokuSolver/Views/MainWindow.xaml.cs
+++ b/SudokuSolver/Views/MainWindow.xaml.cs
@@ -135,6 +135,8 @@ internal sealed partial class MainWindow : WindowBase
         {
             processingClose = true;
 
+            CloseMenuFlyouts();
+
             // cannot have more than one content dialog open at the same time
             aboutBox?.Hide();
             errorDialog?.Hide();
@@ -163,6 +165,15 @@ internal sealed partial class MainWindow : WindowBase
 
             if (lastWindow)
                 await Settings.Data.Save();
+        }
+    }
+
+    private void CloseMenuFlyouts()
+    {
+        foreach (Popup popup in VisualTreeHelper.GetOpenPopupsForXamlRoot(layoutRoot.XamlRoot))
+        {
+            if (popup.Child is MenuFlyoutPresenter)
+                popup.IsOpen = false;
         }
     }
 


### PR DESCRIPTION
Don't want to have menu flyouts open when displaying a "save existing first" content dialog