### PR TITLE
Ignore a second close event on Alt+F4

### DIFF
--- a/SudokuSolver/Views/MainWindow.xaml.cs
+++ b/SudokuSolver/Views/MainWindow.xaml.cs
@@ -127,11 +127,15 @@ internal sealed partial class MainWindow : WindowBase
     {
         // This is called from the File menu's close click handler and
         // also the AppWindow.Closing event handler. 
+
+        if (processingClose)  // a second, or further attempts to close while prompting to save existing
+            return;
+
         Status status = Status.Continue;
 
-        if (IsPuzzleModified && !processingClose)  // the first user attempt to close, a second will always succeed
+        if (IsPuzzleModified) 
         {
-            processingClose = true;
+            processingClose = true; // the first attempt to close
 
             CloseMenuFlyouts();
 
@@ -142,7 +146,7 @@ internal sealed partial class MainWindow : WindowBase
             status = await SaveExistingFirst();
         }
 
-        if (status == Status.Cancelled)  // the save existing prompt was cancelled
+        if (status == Status.Cancelled)  // the save existing prompt was canceled
         {
             processingClose = false;
             FocusLastSelectedCell();


### PR DESCRIPTION
Typing Alt+F4 generates two AppWindow close events (from two WM_SYSCOMMAND messages with wParam = SC_CLOSE). This buggered my close logic where the second close event was assumed to be from the user.