### PR TITLE
Improve error handling opening files

### DIFF
--- a/Puzzles/Test/invalid_version_3.sdku
+++ b/Puzzles/Test/invalid_version_3.sdku
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Sudoku version="3">
+  <Cell>
+    <x>0</x>
+    <y>0</y>
+    <value>3</value>
+    <origin>User</origin>
+  </Cell>
+  <Cell>
+    <x>1</x>
+    <y>0</y>
+    <value>2</value>
+    <origin>User</origin>
+  </Cell>
+  <Cell>
+    <x>2</x>
+    <y>0</y>
+    <value>6</value>
+    <origin>User</origin>
+  </Cell>
+  <Cell>
+    <x>3</x>
+    <y>0</y>
+    <value>4</value>
+    <origin>User</origin>
+  </Cell>
+</Sudoku>

--- a/SudokuSolver/ViewModels/PuzzleViewModel.cs
+++ b/SudokuSolver/ViewModels/PuzzleViewModel.cs
@@ -112,24 +112,23 @@ internal sealed class PuzzleViewModel : INotifyPropertyChanged
 
     public void Open(Stream stream)
     {
+        PuzzleModel newModel = new PuzzleModel();
+
         try
         {
-            model.Clear();
-            model.Open(stream);
-            initialState = new PuzzleModel(model);
-            IsModified = false;
+            newModel.Open(stream);
         }
         catch
         {
-            model.Clear();
             throw;
         }
-        finally
-        {
-            UpdateView();
-            undoHelper.Push(model);
-            UpdateMenuItemsDisabledState();
-        }
+
+        model = newModel;
+        initialState = new PuzzleModel(model);
+        IsModified = false;
+        UpdateView();
+        undoHelper.Push(model);
+        UpdateMenuItemsDisabledState();
     }
 
     private void UpdateView()


### PR DESCRIPTION
Don't touch the existing puzzle until the file has been successfully read.