### PR TITLE
Use platform in path

### DIFF
--- a/SudokuSolver/Installer/inno_script.iss
+++ b/SudokuSolver/Installer/inno_script.iss
@@ -14,7 +14,7 @@
 #define appDisplayName "Sudoku Solver"
 #define appName "SudokuSolver"
 #define appExeName appName + ".exe"
-#define appVer RemoveFileExt(GetVersionNumbersString("..\bin\Release\win-x64\publish\" + appExeName))
+#define appVer RemoveFileExt(GetVersionNumbersString("..\bin\Release\win-" + platform + "\publish\" + appExeName));
 #define appId "sudukosolver.8628521D92E74106"
 
 [Setup]


### PR DESCRIPTION
Allows separate platform builds rather than always requiring x64 build to be published.