### PR TITLE
Sort out content dialogs

### DIFF
--- a/SudokuSolver/Views/ConfirmSaveDialog.cs
+++ b/SudokuSolver/Views/ConfirmSaveDialog.cs
@@ -2,13 +2,13 @@
 
 internal sealed partial class ConfirmSaveDialog : ContentDialog
 {
-    public ConfirmSaveDialog(string puzzleName, XamlRoot xamlRoot, ElementTheme actualTheme) : base()
+    public ConfirmSaveDialog(FrameworkElement parent, string puzzleName) : base()
     {
         // for entrance transition animation
         Style = Application.Current.Resources["DefaultContentDialogStyle"] as Style;
 
-        XamlRoot = xamlRoot;
-        RequestedTheme = actualTheme;
+        XamlRoot = parent.XamlRoot;
+        RequestedTheme = parent.ActualTheme;
 
         Title = App.cAppDisplayName;
         PrimaryButtonText = App.Instance.ResourceLoader.GetString("SaveButton");
@@ -19,5 +19,10 @@ internal sealed partial class ConfirmSaveDialog : ContentDialog
         Content = string.Format(template, puzzleName);
 
         DefaultButton = ContentDialogButton.Primary;
+    }
+
+    public static ConfirmSaveDialog Factory(FrameworkElement parent, string message, string _)
+    {
+        return new ConfirmSaveDialog(parent, message);
     }
 }

--- a/SudokuSolver/Views/ContentDialogHelper.cs
+++ b/SudokuSolver/Views/ContentDialogHelper.cs
@@ -1,0 +1,77 @@
+﻿namespace SudokuSolver.Views;
+
+internal class ContentDialogHelper
+{
+    private ContentDialog? currentDialog = null;
+    private PuzzleTabViewItem? parentTab = null;
+    private ContentDialog? previousDialog = null;
+
+    public async Task<ContentDialogResult> ShowFileOpenErrorDialogAsync(PuzzleTabViewItem parent, string message, string details)
+    {
+        return await ShowDialogAsync(parent, FileOpenErrorDialog.Factory, message, details);
+    }
+
+    public async Task<ContentDialogResult> ShowErrorDialogAsync(PuzzleTabViewItem parent, string message, string details)
+    {
+        return await ShowDialogAsync(parent, ErrorDialog.Factory, message, details);
+    }
+
+    public async Task<ContentDialogResult> ShowConfirmSaveDialogAsync(PuzzleTabViewItem parent, string path)
+    {
+        return await ShowDialogAsync(parent, ConfirmSaveDialog.Factory, path, string.Empty);
+    }
+
+    private async Task<ContentDialogResult> ShowDialogAsync(PuzzleTabViewItem parent, Func<FrameworkElement, string, string, ContentDialog> f, string message, string details)
+    {
+        Debug.Assert(previousDialog is null);
+        previousDialog = currentDialog;
+
+        currentDialog = f(parent, message, details); 
+        
+        AddOpenClosedEventHandlers(currentDialog);
+        previousDialog?.Hide();
+
+        while (previousDialog is not null)
+        {
+            // Hide() is also asynchronous
+            // Please don't try that at home kids. I'm a trained professional.
+            await Task.Delay(10);
+        }
+
+        parentTab = parent;
+        return await currentDialog.ShowAsync();
+    }
+
+    private void AddOpenClosedEventHandlers(ContentDialog dialog)
+    {
+        dialog.Opened += ContentDialog_Opened;
+        dialog.Closed += ContentDialog_Closed;
+
+        void ContentDialog_Opened(ContentDialog sender, ContentDialogOpenedEventArgs args)
+        {
+            // workaround for https://github.com/microsoft/microsoft-ui-xaml/issues/5739
+            // focus can escape a content dialog when access keys are shown via the alt key...
+            parentTab?.AdjustMenuAccessKeys(enable: false);
+        }
+
+        void ContentDialog_Closed(ContentDialog sender, ContentDialogClosedEventArgs args)
+        {
+            parentTab?.AdjustMenuAccessKeys(enable: true);
+
+            if (previousDialog is not null) // waiting for the previous to close first before opening a second
+            {
+                previousDialog = null;
+            }
+            else 
+            {
+                currentDialog = null;
+            }
+        }
+    }
+
+    public bool IsContentDialogOpen => currentDialog is not null;
+
+    public bool IsConfirmSaveDialogOpen => currentDialog is ConfirmSaveDialog;
+
+    public FileOpenErrorDialog? GetFileOpenErrorDialog() => currentDialog as FileOpenErrorDialog;
+}

--- a/SudokuSolver/Views/ErrorDialog.cs
+++ b/SudokuSolver/Views/ErrorDialog.cs
@@ -1,27 +1,31 @@
 ﻿using SudokuSolver.Utilities;
 
-namespace SudokuSolver.Views
+namespace SudokuSolver.Views;
+
+internal sealed partial class ErrorDialog : ContentDialog
 {
-    internal sealed partial class ErrorDialog : ContentDialog
+    public ErrorDialog(FrameworkElement parent, string message, string details) : base()
     {
-        public ErrorDialog(string message, string details, XamlRoot xamlRoot, ElementTheme actualTheme) : base()
+        // for entrance transition animation
+        Style = (Style)Application.Current.Resources["DefaultContentDialogStyle"];
+
+        XamlRoot = parent.XamlRoot;
+        RequestedTheme = parent.ActualTheme;
+
+        Title = App.cAppDisplayName;
+        PrimaryButtonText = App.Instance.ResourceLoader.GetString("OKButton");
+
+        DefaultButton = ContentDialogButton.Primary;
+
+        Loaded += (s, e) =>
         {
-            // for entrance transition animation
-            Style = (Style)Application.Current.Resources["DefaultContentDialogStyle"];
+            Utils.PlayExclamation();
+            Content = $"{message}{Environment.NewLine}{Environment.NewLine}{details}";
+        };
+    }
 
-            XamlRoot = xamlRoot;
-            RequestedTheme = actualTheme;
-
-            Title = App.cAppDisplayName;
-            PrimaryButtonText = App.Instance.ResourceLoader.GetString("OKButton");
-
-            DefaultButton = ContentDialogButton.Primary;
-
-            Loaded += (s, e) =>
-            {
-                Utils.PlayExclamation();
-                Content = $"{message}{Environment.NewLine}{Environment.NewLine}{details}";
-            };
-        }
+    public static ErrorDialog Factory(FrameworkElement parent, string message, string details)
+    {
+        return new ErrorDialog(parent, message, details);
     }
 }

--- a/SudokuSolver/Views/FileOpenErrorDialog.xaml.cs
+++ b/SudokuSolver/Views/FileOpenErrorDialog.xaml.cs
@@ -4,18 +4,20 @@ namespace SudokuSolver.Views;
 
 internal sealed partial class FileOpenErrorDialog : ContentDialog
 {
-    public FileOpenErrorDialog(XamlRoot xamlRoot, ElementTheme actualTheme)
+    public FileOpenErrorDialog(FrameworkElement parent, string message, string details)
     {
         this.InitializeComponent();
 
         Style = (Style)Application.Current.Resources["DefaultContentDialogStyle"];
 
-        XamlRoot = xamlRoot;
-        RequestedTheme = actualTheme;
+        XamlRoot = parent.XamlRoot;
+        RequestedTheme = parent.ActualTheme;
 
         Title = App.cAppDisplayName;
         PrimaryButtonText = App.Instance.ResourceLoader.GetString("OKButton");
         DefaultButton = ContentDialogButton.Primary;
+
+         AddError(message, details);
 
         Loaded += (s, e) => Utils.PlayExclamation();
     }
@@ -42,5 +44,10 @@ internal sealed partial class FileOpenErrorDialog : ContentDialog
 
             ErrorTreeView.RootNodes.Add(parent);
         }
+    }
+
+    public static FileOpenErrorDialog Factory(FrameworkElement parent, string message, string details)
+    {
+        return new FileOpenErrorDialog(parent, message, details);
     }
 }

--- a/SudokuSolver/Views/MainWindow.cs
+++ b/SudokuSolver/Views/MainWindow.cs
@@ -250,7 +250,7 @@ internal partial class MainWindow : Window
 
     private bool CanCloseTab(object? param)
     {
-        return !IsContentDialogOpen();
+        return !ContentDialogHelper.IsContentDialogOpen;
     }
 
     private async void ExecuteCloseTabAsync(object? param)


### PR DESCRIPTION
a) prevent focus escaping content dialogs when access keys are shown via the alt key b) avoid opening two content dialogs i.e. when opening a corrupt file while already displaying a confirm save existing first dialog.