### PR TITLE
Make ContentDialogs more modal

### DIFF
--- a/SudokuSolver/NativeMethods.txt
+++ b/SudokuSolver/NativeMethods.txt
@@ -15,3 +15,6 @@ PostMessage
 WM_DPICHANGED
 SHAddToRecentDocs
 GetDoubleClickTime
+FindWindowEx
+EnableWindow
+WM_NCHITTEST

--- a/SudokuSolver/Views/ContentDialogHelper.cs
+++ b/SudokuSolver/Views/ContentDialogHelper.cs
@@ -68,7 +68,19 @@ internal class ContentDialogHelper
         // (it makes no difference if the content dialog itself has any access keys)
         selectedTab.AdjustMenuAccessKeys(enable: false);
 
+        EnableCaptionButtons(false);
         return await currentDialog.ShowAsync();
+    }
+
+    private void EnableCaptionButtons(bool enable)
+    {
+        HWND hWnd = PInvoke.FindWindowEx((HWND)parentWindow.WindowPtr, HWND.Null, "InputNonClientPointerSource", null);
+        Debug.Assert(!hWnd.IsNull);
+
+        if (!hWnd.IsNull)
+        {
+            PInvoke.EnableWindow(hWnd, enable);
+        }
     }
 
     private static void CurrentDialog_Loaded(object sender, RoutedEventArgs e)
@@ -84,6 +96,7 @@ internal class ContentDialogHelper
 
     private void ContentDialog_Closing(ContentDialog sender, ContentDialogClosingEventArgs args)
     {
+        EnableCaptionButtons(true);
         selectedTab?.AdjustMenuAccessKeys(enable: true);
     }
 

--- a/SudokuSolver/Views/MainWindow.cs
+++ b/SudokuSolver/Views/MainWindow.cs
@@ -96,7 +96,6 @@ internal partial class MainWindow : Window
 
     private LRESULT NewSubWindowProc(HWND hWnd, uint uMsg, WPARAM wParam, LPARAM lParam, nuint uIdSubclass, nuint dwRefData)
     {
-        const int VK_SPACE = 0x0020;
         const int HTCAPTION = 0x0002;
 
         switch (uMsg)
@@ -120,13 +119,34 @@ internal partial class MainWindow : Window
                 break;
             }
 
-            case PInvoke.WM_SYSCOMMAND when (lParam == VK_SPACE) && (AppWindow.Presenter.Kind != AppWindowPresenterKind.FullScreen):
+            case PInvoke.WM_SYSCOMMAND when (lParam == (int)VirtualKey.Space) && !ContentDialogHelper.IsContentDialogOpen:
             {
                 HideSystemMenu();
                 ShowSystemMenu(viaKeyboard: true);
                 return (LRESULT)0;
             }
 
+            case PInvoke.WM_SYSCOMMAND when ContentDialogHelper.IsContentDialogOpen:
+            {
+                return (LRESULT)0; 
+            }
+
+            case PInvoke.WM_NCHITTEST when ContentDialogHelper.IsContentDialogOpen:
+            {
+                LRESULT result = PInvoke.DefSubclassProc(hWnd, uMsg, wParam, lParam);
+
+                const int HTNOWHERE = 0;
+                const int HTLEFT = 10;
+                const int HTBOTTOMRIGHT = 17;
+
+                if ((result >= HTLEFT) && (result <= HTBOTTOMRIGHT))
+                {
+                    return (LRESULT)HTNOWHERE;   // disable resize border
+                }
+
+                return result;
+            }
+            
             case PInvoke.WM_NCRBUTTONUP when wParam == HTCAPTION:
             {
                 HideSystemMenu();

--- a/SudokuSolver/Views/MainWindow.xaml.cs
+++ b/SudokuSolver/Views/MainWindow.xaml.cs
@@ -94,16 +94,10 @@ internal sealed partial class MainWindow : Window, ISession
         }
         else
         {
-            // Closing the window is reentrant when awaiting a content dialog.
-            // Unfortunately there doesn't seem to be a way to disable the caption close button
-            if (ContentDialogHelper.IsContentDialogOpen)
-            {
-                Utils.PlayExclamation();
-            }
-            else
-            {
-                await AttemptToCloseTabsAsync(Tabs.TabItems);
-            }
+            // this would be reentrant if awaiting a content dialog and 
+            // the window was still closeable (caption close button or Alt+F4)
+            Debug.Assert(!ContentDialogHelper.IsContentDialogOpen);
+            await AttemptToCloseTabsAsync(Tabs.TabItems);
         }
     }
 


### PR DESCRIPTION
Disable parent window caption buttons and resizing. Definitely a hack, but since the WinAppSdk is self contained, I should be able to get away with it...