### PR TITLE
Avoid window closing when dragging settings tabs

### DIFF
--- a/SudokuSolver/Views/MainWindow.xaml.cs
+++ b/SudokuSolver/Views/MainWindow.xaml.cs
@@ -319,19 +319,22 @@ internal sealed partial class MainWindow : Window, ISession
             MainWindow? window = App.Instance.GetWindowForElement(sourceTab);
             window?.CloseTab(sourceTab);
 
-            if (sourceTab is PuzzleTabViewItem existingPuzzleTab)
+            if (sourceTab is PuzzleTabViewItem draggedPuzzleTab)
             {
-                AddTab(new PuzzleTabViewItem(this, existingPuzzleTab), index);
+                AddTab(new PuzzleTabViewItem(this, draggedPuzzleTab), index);
             }
-            else if (sourceTab is SettingsTabViewItem existingSettingsTab)
+            else if (sourceTab is SettingsTabViewItem draggedSettingsTab)
             {
+                TabViewItem? existing = Tabs.TabItems.FirstOrDefault(x => x is SettingsTabViewItem) as TabViewItem;
+
                 // preserve the drop position and existing expander state
-                if (Tabs.TabItems.FirstOrDefault(x => x is SettingsTabViewItem) is TabViewItem existing)
+                // add first before closing an existing settings tab to avoid the window closing
+                AddTab(new SettingsTabViewItem(this, draggedSettingsTab), index);
+
+                if (existing is not null)
                 {
                     CloseTab(existing);
                 }
-
-                AddTab(new SettingsTabViewItem(this, existingSettingsTab), index);
             }
         }
     }


### PR DESCRIPTION
When a settings tab was dragged on to a window containing only another settings tab the window closed when the existing settings tab was closed