### PR TITLE
Fix editing puzzles after showing print preview

### DIFF
--- a/SudokuSolver/Views/PrintHelper.cs
+++ b/SudokuSolver/Views/PrintHelper.cs
@@ -59,7 +59,7 @@ internal sealed class PrintHelper
         settings = Settings.Instance.PrintSettings.Clone();
 
         // a user control containing a puzzle view
-        printPage = new PrintPage(tab.ViewModel);
+        printPage = new PrintPage(tab.GetSessionData());
 
         // the printed object must be part of the visual tree
         rootVisual = printCanvas;
@@ -263,7 +263,6 @@ internal sealed class PrintHelper
 
             if (settings.ShowHeader)
             {
-                printPage.SetHeaderText(headerText);
                 headerHeight = printPage.GetHeaderHeight();
                 layoutInvalid |= printPage.SetHeadingLocation(new Point(leftMargin, topMargin));
                 layoutInvalid |= printPage.SetHeadingWidth(pd.PageSize.Width - (leftMargin + rightMargin));

--- a/SudokuSolver/Views/PrintPage.xaml.cs
+++ b/SudokuSolver/Views/PrintPage.xaml.cs
@@ -9,10 +9,47 @@ internal sealed partial class PrintPage : UserControl
         this.InitializeComponent();
     }
 
-    public PrintPage(PuzzleViewModel viewModel) : this()
+    public PrintPage(XElement root) : this()
     {
         RequestedTheme = ElementTheme.Light;
-        Puzzle.ViewModel = viewModel;
+        Puzzle.ViewModel = new PuzzleViewModel();
+
+        XElement? data = root.Element("title");
+
+        if (data is not null)
+        {
+            Header.Text = data.Value;
+        }
+
+        bool isModified = false;
+
+        data = root.Element("modified");
+
+        if (data is not null)
+        {
+            isModified = data.Value == "true";
+        }
+
+        data = root.Element("showPossibles");
+
+        if (data is not null)
+        {
+            Puzzle.ViewModel.ShowPossibles = data.Value == "true";
+        }
+
+        data = root.Element("showSolution");
+
+        if (data is not null)
+        {
+            Puzzle.ViewModel.ShowSolution = data.Value == "true";
+        }
+
+        data = root.Element("Sudoku");
+
+        if (data is not null)
+        {
+            Puzzle.ViewModel.LoadXml(data, isModified);
+        }
     }
 
     private static bool SetLocation(UIElement element, Point location)
@@ -70,8 +107,6 @@ internal sealed partial class PrintPage : UserControl
     
         return false;
     }
-
-    public void SetHeaderText(string? text) => Header.Text = text ?? string.Empty;
 
     public double GetHeaderHeight() => Header.Height;
 }


### PR DESCRIPTION
Another case of trying to reuse the puzzle view model for the printed page. Just create a new one and load it with session data.