### PR TITLE
Correct parameter order

### DIFF
--- a/SudokuSolver/Utilities/ObservableArray.cs
+++ b/SudokuSolver/Utilities/ObservableArray.cs
@@ -19,7 +19,7 @@ internal partial class ObservableArray<T> : ICollection<T>, INotifyCollectionCha
             T original = items[index];
             items[index] = value;
 
-            CollectionChanged?.Invoke(this, new(NotifyCollectionChangedAction.Replace, original, value, index));
+            CollectionChanged?.Invoke(this, new(NotifyCollectionChangedAction.Replace, value, original, index));
         }
     }
 


### PR DESCRIPTION
Not that they or the index are actually used. The auto generated code updates every item relying on dependency object changed notifications to limit the actual updates