### PR TITLE
Remove trial origin

### DIFF
--- a/SudokuSolver/Common/Origins.cs
+++ b/SudokuSolver/Common/Origins.cs
@@ -1,3 +1,3 @@
 ﻿namespace SudokuSolver.Common;
 
-public enum Origins { NotDefined, Provided, User, Calculated, Trial }
+public enum Origins { NotDefined, Provided, User, Calculated }

--- a/SudokuSolver/Models/PuzzleModel.cs
+++ b/SudokuSolver/Models/PuzzleModel.cs
@@ -944,11 +944,11 @@ internal sealed class PuzzleModel : IEquatable<PuzzleModel>
     //      which solution is found will be indeterminate. That isn't optimal, getting
     //      different results for the same action.      
 
-    private readonly ConcurrentStack<PuzzleModel> modelCache = new();
+    private readonly System.Collections.Concurrent.ConcurrentStack<PuzzleModel> modelCache = new();
 
     private void AttemptSimpleTrialAndError()
     {
-        List<(int index, int value)> attempts = new(Cells.Count);
+        List<(int index, int value)> attempts = new(CellList.Count);
     
         foreach (Cell cell in Cells.AsSpan())
         {
@@ -985,7 +985,7 @@ internal sealed class PuzzleModel : IEquatable<PuzzleModel>
 
                     if (!state.IsStopped)
                     {
-                        localModel.SetCellValue(attempt.index, attempt.value, Origins.Trial);
+                        localModel.SetCellValue(attempt.index, attempt.value, Origins.Calculated);
 
                         if (!state.IsStopped && localModel.PuzzleIsComplete && localModel.PuzzleIsErrorFree())
                         {
@@ -1030,7 +1030,7 @@ internal sealed class PuzzleModel : IEquatable<PuzzleModel>
 
                 while ((value = temp.First) > 0)
                 {        
-                    SetCellValue(cell.Index, value, Origins.Trial);
+                    SetCellValue(cell.Index, value, Origins.Calculated);
 
                     if (PuzzleIsComplete && PuzzleIsErrorFree())
                     {

--- a/SudokuSolver/Resources/Themes.xaml
+++ b/SudokuSolver/Resources/Themes.xaml
@@ -9,7 +9,6 @@
             <SolidColorBrush x:Key="UserCellBrush" Color="{ThemeResource SystemColorButtonTextColor}"/>
             <SolidColorBrush x:Key="ProvidedCellBrush" Color="{ThemeResource SystemColorButtonTextColor}"/>
             <SolidColorBrush x:Key="CalculatedCellBrush" Color="Gray"/>
-            <SolidColorBrush x:Key="TrialCellBrush" Color="Gray"/>
             <SolidColorBrush x:Key="CellFillBrush" Color="{ThemeResource SystemColorWindowColor}"/>
             <SolidColorBrush x:Key="CellPossiblesBrush" Color="Gray"/>
             <SolidColorBrush x:Key="PossiblesHorizontalBrush" Color="Red"/>
@@ -28,7 +27,6 @@
             <SolidColorBrush x:Key="UserCellBrush" Color="White"/>
             <SolidColorBrush x:Key="ProvidedCellBrush" Color="LightBlue"/>
             <SolidColorBrush x:Key="CalculatedCellBrush" Color="Blue"/>
-            <SolidColorBrush x:Key="TrialCellBrush" Color="Blue"/>
             <SolidColorBrush x:Key="CellFillBrush" Color="Black"/>
             <SolidColorBrush x:Key="CellPossiblesBrush" Color="Gray"/>
             <SolidColorBrush x:Key="PossiblesHorizontalBrush" Color="Red"/>
@@ -50,7 +48,6 @@
             <SolidColorBrush x:Key="UserCellBrush" Color="Black"/>
             <SolidColorBrush x:Key="ProvidedCellBrush" Color="Blue"/>
             <SolidColorBrush x:Key="CalculatedCellBrush" Color="LightBlue"/>
-            <SolidColorBrush x:Key="TrialCellBrush" Color="LightBlue"/>
             <SolidColorBrush x:Key="CellFillBrush" Color="White"/>
             <SolidColorBrush x:Key="CellPossiblesBrush" Color="LightGray"/>
             <SolidColorBrush x:Key="PossiblesHorizontalBrush" Color="Red"/>

--- a/SudokuSolver/ViewModels/PuzzleViewModel.cs
+++ b/SudokuSolver/ViewModels/PuzzleViewModel.cs
@@ -71,13 +71,13 @@ internal sealed partial class PuzzleViewModel : INotifyPropertyChanged
                     return model.Edit;
                 }
 
-                if ((currentOrigin == Origins.Trial) || (currentOrigin == Origins.Calculated))
+                if (currentOrigin == Origins.Calculated)
                 {
                     return model.EditForced;
                 }
             }
 
-            if ((currentValue == newValue) && ((currentOrigin == Origins.Trial) || (currentOrigin == Origins.Calculated)))
+            if ((currentValue == newValue) && (currentOrigin == Origins.Calculated))
             {
                 return model.SetOrigin;
             }
@@ -198,7 +198,7 @@ internal sealed partial class PuzzleViewModel : INotifyPropertyChanged
 
     private void UpdateViewForShowSolutionStateChange()
     {
-        UpdateViewWhere(cell => cell.Origin == Origins.Calculated || cell.Origin == Origins.Trial);
+        UpdateViewWhere(cell => cell.Origin == Origins.Calculated);
     }
 
     private void UpdateViewWhere(Func<Cell, bool> predicate)

--- a/SudokuSolver/Views/Cell.xaml
+++ b/SudokuSolver/Views/Cell.xaml
@@ -17,11 +17,6 @@
                         <Setter Target="CellValue.Foreground" Value="{ThemeResource CalculatedCellBrush}"/>
                     </VisualState.Setters>
                 </VisualState>
-                <VisualState x:Name="Trial">
-                    <VisualState.Setters>
-                        <Setter Target="CellValue.Foreground" Value="{ThemeResource TrialCellBrush}"/>
-                    </VisualState.Setters>
-                </VisualState>
                 <VisualState x:Name="Provided">
                     <VisualState.Setters>
                         <Setter Target="CellValue.Foreground" Value="{ThemeResource ProvidedCellBrush}"/>


### PR DESCRIPTION
It made it difficult to detect if a puzzle had been modified and it hasn't been useful for debugging for some time.